### PR TITLE
Update healed locators in CssTest.java

### DIFF
--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -64,9 +64,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.CSS, "test_tag")
+                .findTestElement(LocatorType.CSS, "input#change_element")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.CSS, "test_tag");
+                .findTestElement(LocatorType.CSS, "input#change_element");
     }
 
     @Test


### PR DESCRIPTION
This merge request updates the 'CssTest.java' file to replace the broken locator 'test_tag' with the healed locator 'input#change_element'. This change ensures that the automated tests remain robust and reliable, aligning with the latest locator healing data from Healenium.