### PR TITLE
Update broken locator in CssTest

### DIFF
--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -64,9 +64,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.CSS, "test_tag")
+                .findTestElement(LocatorType.CSS, "input#change_element")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.CSS, "test_tag");
+                .findTestElement(LocatorType.CSS, "input#change_element");
     }
 
     @Test


### PR DESCRIPTION
Updated the broken locator 'test_tag:first-child' with the healed locator 'input#change_element' in the CssTest.java file to enhance test reliability.