### PR TITLE
Update healed locators

### DIFF
--- a/src/test/java/com/epam/healenium/tests/XpathTest.java
+++ b/src/test/java/com/epam/healenium/tests/XpathTest.java
@@ -18,9 +18,9 @@ public class XpathTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.XPATH, "//*[@id='change:name']")
+                .findTestElement(LocatorType.CSS_SELECTOR, "input#newName")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.XPATH, "//*[@id='change:name']");
+                .findTestElement(LocatorType.CSS_SELECTOR, "input#newName");
     }
 
     @Test


### PR DESCRIPTION
This pull request replaces broken locators with their healed alternatives as suggested by Healenium. The `XpathTest.java` has been updated to use `input#newName` instead of the broken XPath locator `//*[@id='change:name']`. This ensures more robust and reliable automated tests.