### PR TITLE
Fix broken locator in SemanticTest

### DIFF
--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -85,8 +85,8 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.TAG_NAME, "test_tag")
+                .findTestElement(LocatorType.TAG_NAME, "input#change_element")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.TAG_NAME, "test_tag");
+                .findTestElement(LocatorType.TAG_NAME, "input#change_element");
     }
 }


### PR DESCRIPTION
Replaced broken locator 'test_tag' with healed locator 'input#change_element' in the method 'testFindElementByTagName'. This change enhances the robustness of the test suite.