### PR TITLE
Update broken locators in SemanticTest

### DIFF
--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -98,7 +98,7 @@ public class SemanticTest extends BaseTest {
     public void testPrice() {
         FrameworkPage page = pages.get(TEST_ENV);
         page.openPage();
-        WebElement element = driver.findElement(By.className("total_price"));
+        WebElement element = driver.findElement(By.xpath("//*[@id='change_element']"));
         element.click();
         driver.findElement(By.id("close_popup"));
     }


### PR DESCRIPTION
This pull request updates the locator in the `SemanticTest.java` file. The broken locator 'By.className: total_price' has been replaced with the healed locator 'By.xpath://*[@id='change_element']'. This change ensures the test suite maintains its robustness and reliability by using valid locators. Please review the changes and merge if everything looks good.