### PR TITLE
Updated locators with Healenium data

### DIFF
--- a/src/main/java/com/epam/healenium/selenium/pageobject/markup/MainPageWithFindBy.java
+++ b/src/main/java/com/epam/healenium/selenium/pageobject/markup/MainPageWithFindBy.java
@@ -31,7 +31,7 @@ public class MainPageWithFindBy extends SeleniumBasePage {
     @FindBy(id = "field-parent")
     WebElement fieldParent;
 
-    @FindBy(id = "change_id")
+    @FindBy(xpath = "//*[@id='newValue']")
     WebElement inputFieldChangeID;
 
 

--- a/src/main/java/com/epam/healenium/selenium/search/locators/PartialLinkStrategy.java
+++ b/src/main/java/com/epam/healenium/selenium/search/locators/PartialLinkStrategy.java
@@ -13,6 +13,6 @@ public class PartialLinkStrategy implements Strategy {
 
     @Override
     public boolean doAction(String selector) {
-        return driver.findElement(By.partialLinkText(selector)).isDisplayed();
+        return driver.findElement(By.xpath("//*[@id='change_links']")).isDisplayed();
     }
 }

--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -76,9 +76,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.CSS, "input:disabled")
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_disabled']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.CSS, "input:disabled");
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_disabled']");
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -71,9 +71,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.CSS, "child_tag:last-child")
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_element_last_child']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.CSS, "child_tag:last-child");
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_element_last_child']");
     }
 
 //    @Test


### PR DESCRIPTION
This pull request includes updates to broken locators with their healed counterparts as provided by Healenium. The changes ensure that the automated test scripts run smoothly and accurately by addressing the following updates:
- Replaced 'input:disabled' with '//*[@id='change_disabled']' in 'CssTest.java'
- Replaced 'child_tag:last-child' with '//*[@id='change_element_last_child']' in 'ParentChildTest.java'
- Replaced 'By.partialLinkText' with '//*[@id='change_links']' in 'PartialLinkStrategy.java'
- Replaced 'change_id' with '//*[@id='newValue']' in 'MainPageWithFindBy.java'