### PR TITLE
Update broken locators with healed locators

### DIFF
--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -64,9 +64,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.CSS, "test_tag")
+                .findTestElement(By.xpath, "//*[@id='change_element']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.CSS, "test_tag");
+                .findTestElement(By.xpath, "//*[@id='change_element']");
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -51,9 +51,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.LINK_TEXT, "Change: LinkText, PartialLinkText")
+                .findTestElement(By.xpath, "//*[@id='change_links']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.LINK_TEXT, "Change: LinkText, PartialLinkText");
+                .findTestElement(By.xpath, "//*[@id='change_links']");
     }
 
     @Test
@@ -63,9 +63,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.NAME, "change_name")
+                .findTestElement(By.xpath, "//*[@id='newName']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.NAME, "change_name");
+                .findTestElement(By.xpath, "//*[@id='newName']");
     }
 
     @Test
@@ -75,9 +75,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.PARTIAL_LINK_TEXT, "PartialLinkText")
+                .findTestElement(By.xpath, "//*[@id='change_links']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.PARTIAL_LINK_TEXT, "PartialLinkText");
+                .findTestElement(By.xpath, "//*[@id='change_links']");
     }
 
     @Test
@@ -87,9 +87,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.TAG_NAME, "test_tag")
+                .findTestElement(By.xpath, "//*[@id='change_element']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.TAG_NAME, "test_tag");
+                .findTestElement(By.xpath, "//*[@id='change_element']");
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses the updates of broken locators with their healed versions based on the latest data. Changes have been made to the following files:

- src/test/java/com/epam/healenium/tests/SemanticTest.java
- src/test/java/com/epam/healenium/tests/CssTest.java

The updates include:

- Replacing 'PartialLinkText' with '//*[@id="change_links"]'
- Replacing 'test_tag' with '//*[@id="change_element"]'
- Replacing 'Change: LinkText, PartialLinkText' with '//*[@id="change_links"]'
- Replacing 'change_name' with '//*[@id="newName"]'

These changes ensure that the automated test scripts continue to function accurately with the corrected locators.