### PR TITLE
Locator Updates - Healed Locators

### DIFF
--- a/src/main/java/com/epam/healenium/selenium/pageobject/markup/MainPageWithFindBy.java
+++ b/src/main/java/com/epam/healenium/selenium/pageobject/markup/MainPageWithFindBy.java
@@ -46,7 +46,7 @@ public class MainPageWithFindBy extends SeleniumBasePage {
 
     @FindBy (name =  "change_name")
     WebElement inputFieldChangeName;
-    @FindBy (linkText = "Change: LinkText, PartialLinkText")
+    @FindBy (xpath = "//*[@id='change_links']")
     WebElement inputFieldChangeLinkText;
 
     @FindBy(id = "form_checked1")

--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -65,9 +65,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag")).isDisplayed();
+        driver.findElement(By.xpath("//*[@id='change_element']")).isDisplayed();
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag")).isDisplayed();
+        driver.findElement(By.xpath("//*[@id='change_element']")).isDisplayed();
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -52,9 +52,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.LINK_TEXT, "Change: LinkText, PartialLinkText")
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_links']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.LINK_TEXT, "Change: LinkText, PartialLinkText");
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_links']");
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -88,8 +88,8 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.tagName("test_tag")).isDisplayed();
+        driver.findElement(By.xpath("//*[@id='change_element']")).isDisplayed();
         page.clickSubmitButton();
-        driver.findElement(By.tagName("test_tag")).isDisplayed();
+        driver.findElement(By.xpath("//*[@id='change_element']")).isDisplayed();
     }
 }

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -76,9 +76,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.PARTIAL_LINK_TEXT, "PartialLinkText")
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_links']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.PARTIAL_LINK_TEXT, "PartialLinkText");
+                .findTestElement(LocatorType.XPATH, "//*[@id='change_links']");
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -64,9 +64,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.NAME, "change_name")
+                .findTestElement(LocatorType.XPATH, "//*[@id='newName']")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.NAME, "change_name");
+                .findTestElement(LocatorType.XPATH, "//*[@id='newName']");
     }
 
     @Test


### PR DESCRIPTION
This pull request includes updates to replace broken locators with their healed versions as provided by Healenium. The following changes were made:

1. **Updated `src/test/java/com/epam/healenium/tests/CssTest.java`**:
   - Replaced `By.cssSelector("test_tag")` with `By.xpath("//*[@id='change_element']")`.

2. **Updated `src/main/java/com/epam/healenium/selenium/pageobject/markup/MainPageWithFindBy.java`**:
   - Replaced `@FindBy(linkText = "Change: LinkText, PartialLinkText")` with `@FindBy(xpath = "//*[@id='change_links']")`.

3. **Updated `src/test/java/com/epam/healenium/tests/SemanticTest.java`**:
   - Replaced `findTestElement(LocatorType.LINK_TEXT, "Change: LinkText, PartialLinkText")` with `findTestElement(LocatorType.XPATH, "//*[@id='change_links']")`.
   - Replaced `findTestElement(LocatorType.NAME, "change_name")` with `findTestElement(LocatorType.XPATH, "//*[@id='newName']")`.
   - Replaced `findTestElement(LocatorType.PARTIAL_LINK_TEXT, "PartialLinkText")` with `findTestElement(LocatorType.XPATH, "//*[@id='change_links']")`.

Please review the changes and merge them into the master branch.