### PR TITLE
Update broken locator in CssTest.java

### DIFF
--- a/src/test/java/com/epam/healenium/tests/CssTest.java
+++ b/src/test/java/com/epam/healenium/tests/CssTest.java
@@ -65,9 +65,9 @@ public class CssTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag")).isDisplayed();
+        driver.findElement(By.cssSelector("input#change_element")).isDisplayed();
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag")).isDisplayed();
+        driver.findElement(By.cssSelector("input#change_element")).isDisplayed();
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the broken locator `test_tag` in the file `CssTest.java` to its healed value `input#change_element` as provided by Healenium.

closes #<issue_number>