### PR TITLE
Update Locators in SemanticTest.java

### DIFF
--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -60,9 +60,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.name("change_name"));
+        driver.findElement(By.name("healed_change_name"));
         page.clickSubmitButton();
-        driver.findElement(By.name("change_name"));
+        driver.findElement(By.name("healed_change_name"));
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/SemanticTest.java
+++ b/src/test/java/com/epam/healenium/tests/SemanticTest.java
@@ -48,9 +48,9 @@ public class SemanticTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.linkText("Change: LinkText, PartialLinkText"));
+        driver.findElement(By.linkText("Healed: LinkText, PartialLinkText"));
         page.clickSubmitButton();
-        driver.findElement(By.linkText("Change: LinkText, PartialLinkText"));
+        driver.findElement(By.linkText("Healed: LinkText, PartialLinkText"));
     }
 
     @Test


### PR DESCRIPTION
Updated broken locators to their healed versions as per Healenium data:
- Updated `By.linkText("Change: LinkText, PartialLinkText")` to `By.linkText("Healed: LinkText, PartialLinkText")`.
- Updated `By.name("change_name")` to `By.name("healed_change_name")`.

This ensures the test scripts remain accurate and functional. Please review and merge.