### PR TITLE
Locator Updates - Healed Locators Replacement

### DIFF
--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -57,9 +57,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.cssSelector("input#change_element"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.cssSelector("input#change_element"));
     }
 
     @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -69,9 +69,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.cssSelector("input#change_element_last_child"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.cssSelector("input#change_element_last_child"));
     }
 
 //    @Test


### PR DESCRIPTION
This pull request addresses the replacement of broken locators with their healed counterparts as identified by Healenium. The following updates were made:

1. Replaced `child_tag:last-child` with `input#change_element_last_child` in `src/test/java/com/epam/healenium/tests/ParentChildTest.java`.
2. Replaced `test_tag:first-child` with `input#change_element` in `src/test/java/com/epam/healenium/tests/ParentChildTest.java`.

These changes ensure the accuracy and reliability of the automated test scripts.