### PR TITLE
Update Healenium locators - 2023-11-11

### DIFF
--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -69,9 +69,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
     }
 
 //    @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -57,9 +57,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the following broken locators in the repository:

1. Updated locator in `testCSSFirstChild`:
   - **Broken Locator**: `By.cssSelector("test_tag:first-child")`
   - **Healed Locator**: `By.xpath("//*[@id='change_element']")`

2. Updated locator in `testCSSLastChild`:
   - **Broken Locator**: `By.cssSelector("child_tag:last-child")`
   - **Healed Locator**: `By.xpath("//*[@id='change_element_last_child']")`

These changes ensure that the test cases are aligned with the updated DOM structure.