### PR TITLE
Update Healenium locators - 2023-11-18

### DIFF
--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -69,9 +69,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
     }
 
 //    @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -57,9 +57,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses the following updates to the locators in the test scripts:

1. Replaced `By.cssSelector("test_tag:first-child")` with `By.xpath("//*[@id='change_element']")` in the `testCSSFirstChild` test method.
2. Replaced `By.cssSelector("child_tag:last-child")` with `By.xpath("//*[@id='change_element_last_child']")` in the `testCSSLastChild` test method.

These changes were made to ensure the locators are healed and functional based on the latest updates from Healenium.