### PR TITLE
Healenium Report - Locator Updates

### DIFF
--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -69,9 +69,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
     }
 
 //    @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -57,9 +57,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses the following locator updates based on the Healenium report:

1. Replaced `By.cssSelector("child_tag:last-child")` with `By.xpath("//*[@id='change_element_last_child']")` in `src/test/java/com/epam/healenium/tests/ParentChildTest.java`.
2. Replaced `By.cssSelector("test_tag:first-child")` with `By.xpath("//*[@id='change_element']")` in `src/test/java/com/epam/healenium/tests/ParentChildTest.java`.

These changes aim to fix broken locators and improve test reliability.