### PR TITLE
Healenium Report - 26 May 2025 - 22:39

### DIFF
--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -69,9 +69,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("child_tag:last-child"));
+        driver.findElement(By.xpath("//*[@id='change_element_last_child']"));
     }
 
 //    @Test

--- a/src/test/java/com/epam/healenium/tests/ParentChildTest.java
+++ b/src/test/java/com/epam/healenium/tests/ParentChildTest.java
@@ -57,9 +57,9 @@ public class ParentChildTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
         page.clickSubmitButton();
-        driver.findElement(By.cssSelector("test_tag:first-child"));
+        driver.findElement(By.xpath("//*[@id='change_element']"));
     }
 
     @Test


### PR DESCRIPTION
### Summary of Changes

This pull request addresses the following locator updates based on the Healenium report:

1. Replaced `By.cssSelector("test_tag:first-child")` with `By.xpath("//*[@id='change_element']")`.
2. Replaced `By.cssSelector("child_tag:last-child")` with `By.xpath("//*[@id='change_element_last_child']")`.

### Files Updated
- `src/test/java/com/epam/healenium/tests/ParentChildTest.java`

### Purpose
These changes aim to fix broken locators detected during tests and replace them with healed locators to ensure test stability and accuracy.